### PR TITLE
Avoid an error when using the action

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ async function run() {
     core.setOutput('applied', labelApplied);
   } catch (error) {
     console.error(error);
-    core.setFailed(error.message);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-labels",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## Changes
Instead of it marking the action as failed, simply return silently.
This'll look nicer in the PR overview